### PR TITLE
feat(ecs): add API support for Describe Clusters

### DIFF
--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/EcsControllersSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/EcsControllersSpec.java
@@ -19,6 +19,10 @@ import static io.restassured.RestAssured.get;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.amazonaws.services.ecs.model.Cluster;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.cats.provider.ProviderRegistry;
@@ -27,9 +31,7 @@ import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,6 +71,87 @@ public class EcsControllersSpec extends EcsSpec {
     assertTrue(responseStr.contains(testClusterName));
     assertTrue(responseStr.contains(ECS_ACCOUNT_NAME));
     assertTrue(responseStr.contains(TEST_REGION));
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given cached ECS clusters (names), retrieve detailed description "
+          + "of the cluster from /ecs/ecsDescribeClusters/{account}/{region}"
+          + "\n===")
+  @Test
+  public void getEcsDescribeClustersTest() throws JsonProcessingException {
+    // given
+    ProviderCache ecsCache = providerRegistry.getProviderCache(EcsProvider.NAME);
+    String testClusterName = "example-app-test-Cluster-NSnYsTXmCfV2";
+    String testNamespace = Keys.Namespace.ECS_CLUSTERS.ns;
+
+    String clusterKey = Keys.getClusterKey(ECS_ACCOUNT_NAME, TEST_REGION, testClusterName);
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("account", ECS_ACCOUNT_NAME);
+    attributes.put("region", TEST_REGION);
+    attributes.put("clusterArn", "arn:aws:ecs:::cluster/" + testClusterName);
+    attributes.put("clusterName", testClusterName);
+
+    DefaultCacheResult testResult = buildCacheResult(attributes, testNamespace, clusterKey);
+    ecsCache.addCacheResult("TestAgent", Collections.singletonList(testNamespace), testResult);
+
+    String testClusterName1 = "spinnaker-deployment-cluster";
+    String clusterKey1 = Keys.getClusterKey(ECS_ACCOUNT_NAME, TEST_REGION, testClusterName1);
+    Map<String, Object> attributes1 = new HashMap<>();
+    attributes1.put("account", ECS_ACCOUNT_NAME);
+    attributes1.put("region", TEST_REGION);
+    attributes1.put("clusterArn", "arn:aws:ecs:::cluster/" + testClusterName1);
+    attributes1.put("clusterName", testClusterName1);
+
+    DefaultCacheResult testResult1 = buildCacheResult(attributes1, testNamespace, clusterKey1);
+    ecsCache.addCacheResult("TestAgent", Collections.singletonList(testNamespace), testResult1);
+
+    String testClusterName2 = "TestCluster";
+    String clusterKey2 = Keys.getClusterKey(ECS_ACCOUNT_NAME, TEST_REGION, testClusterName2);
+    Map<String, Object> attributes2 = new HashMap<>();
+    attributes2.put("account", ECS_ACCOUNT_NAME);
+    attributes2.put("region", TEST_REGION);
+    attributes2.put("clusterArn", "arn:aws:ecs:::cluster/" + testClusterName2);
+    attributes2.put("clusterName", testClusterName2);
+
+    DefaultCacheResult testResult2 = buildCacheResult(attributes2, testNamespace, clusterKey2);
+    ecsCache.addCacheResult("TestAgent", Collections.singletonList(testNamespace), testResult2);
+
+    // when
+    String testUrl = getTestUrl("/ecs/ecsDescribeClusters/ecs-account/us-west-2");
+
+    Response response =
+        get(testUrl).then().statusCode(200).contentType(ContentType.JSON).extract().response();
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    Collection<Cluster> clusters =
+        Arrays.asList(objectMapper.readValue(response.asString(), Cluster[].class));
+    // then
+    assertNotNull(clusters);
+    Cluster clusterDescription =
+        (clusters.stream().filter(cluster -> cluster.getClusterName().equals(testClusterName)))
+            .findAny()
+            .get();
+    assertTrue(clusterDescription.getClusterArn().contains(testClusterName));
+    assertTrue(clusterDescription.getCapacityProviders().size() == 2);
+    assertTrue(clusterDescription.getStatus().equals("ACTIVE"));
+
+    Cluster clusterDescription1 =
+        (clusters.stream().filter(cluster -> cluster.getClusterName().equals(testClusterName1)))
+            .findAny()
+            .get();
+    assertTrue(clusterDescription1.getClusterArn().contains(testClusterName1));
+    assertTrue(clusterDescription1.getCapacityProviders().size() == 0);
+    assertTrue(clusterDescription1.getStatus().equals("ACTIVE"));
+
+    Cluster clusterDescription2 =
+        (clusters.stream().filter(cluster -> cluster.getClusterName().equals(testClusterName2)))
+            .findAny()
+            .get();
+    assertTrue(clusterDescription2.getClusterArn().contains(testClusterName2));
+    assertTrue(clusterDescription2.getCapacityProviders().size() == 2);
+    assertTrue(clusterDescription2.getStatus().equals("ACTIVE"));
   }
 
   @DisplayName(".\n===\n" + "Given cached ECS secret, retrieve it from /ecs/secrets" + "\n===")

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsClusterController.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsClusterController.java
@@ -16,11 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.controllers;
 
+import com.amazonaws.services.ecs.model.Cluster;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsCluster;
 import com.netflix.spinnaker.clouddriver.ecs.provider.view.EcsClusterProvider;
 import java.util.Collection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,5 +38,12 @@ public class EcsClusterController {
   @RequestMapping(value = {"/ecs/ecsClusters"})
   public Collection<EcsCluster> getAllEcsClusters() {
     return ecsClusterProvider.getAllEcsClusters();
+  }
+
+  @RequestMapping(value = {"/ecs/ecsDescribeClusters"})
+  public Collection<Cluster> getAllEcsClustersDescription(
+      @RequestParam(value = "account", required = true) String account,
+      @RequestParam(value = "region") String region) {
+    return ecsClusterProvider.getAllEcsClustersDescription(account, region);
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsClusterController.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsClusterController.java
@@ -43,7 +43,7 @@ public class EcsClusterController {
   @RequestMapping(value = {"/ecs/ecsDescribeClusters"})
   public Collection<Cluster> getAllEcsClustersDescription(
       @RequestParam(value = "account", required = true) String account,
-      @RequestParam(value = "region") String region) {
+      @RequestParam(value = "region", required = true) String region) {
     return ecsClusterProvider.getAllEcsClustersDescription(account, region);
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsClusterController.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsClusterController.java
@@ -21,8 +21,8 @@ import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsCluster;
 import com.netflix.spinnaker.clouddriver.ecs.provider.view.EcsClusterProvider;
 import java.util.Collection;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -40,10 +40,9 @@ public class EcsClusterController {
     return ecsClusterProvider.getAllEcsClusters();
   }
 
-  @RequestMapping(value = {"/ecs/ecsDescribeClusters"})
+  @RequestMapping(value = {"/ecs/ecsDescribeClusters/{account}/{region}"})
   public Collection<Cluster> getAllEcsClustersDescription(
-      @RequestParam(value = "account", required = true) String account,
-      @RequestParam(value = "region", required = true) String region) {
+      @PathVariable String account, @PathVariable String region) {
     return ecsClusterProvider.getAllEcsClustersDescription(account, region);
   }
 }


### PR DESCRIPTION
Add support for getting capacity providers using Describe Cluster API.

Backend changes to support: [spinnaker/spinnaker#5400](https://github.com/spinnaker/spinnaker/issues/5400)
